### PR TITLE
feat(llm): 출력 토큰 한도 환경변수화 및 볼드 마크다운 출력 금지

### DIFF
--- a/monix/llm/client.py
+++ b/monix/llm/client.py
@@ -24,6 +24,9 @@ MODEL_FLASH = "gemini-3.1-flash-preview"
 _BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 _HTTP_TIMEOUT = 20
 
+_DEFAULT_CHAT_MAX_OUTPUT_TOKENS = 1024
+_DEFAULT_TOOLS_MAX_OUTPUT_TOKENS = 2048
+
 
 class GeminiClient:
     """Gemini `generateContent` HTTP client.
@@ -34,9 +37,15 @@ class GeminiClient:
         the raw first candidate plus usage info.
     """
 
-    def __init__(self, api_key: Optional[str], model: str) -> None:
+    def __init__(
+        self,
+        api_key: Optional[str],
+        model: str,
+        max_output_tokens: Optional[int] = None,
+    ) -> None:
         self.api_key = api_key
         self.model = model
+        self.max_output_tokens = max_output_tokens
 
     @property
     def enabled(self) -> bool:
@@ -48,7 +57,11 @@ class GeminiClient:
         payload = {
             "system_instruction": {"parts": [{"text": SYSTEM_PROMPT}]},
             "contents": history,
-            "generationConfig": {"maxOutputTokens": 1024},
+            "generationConfig": {
+                "maxOutputTokens": self.max_output_tokens
+                if self.max_output_tokens is not None
+                else _DEFAULT_CHAT_MAX_OUTPUT_TOKENS,
+            },
         }
         try:
             data = self._post(payload)
@@ -82,7 +95,11 @@ class GeminiClient:
         payload: dict[str, Any] = {
             "system_instruction": {"parts": [{"text": SYSTEM_PROMPT}]},
             "contents": history,
-            "generationConfig": {"maxOutputTokens": 2048},
+            "generationConfig": {
+                "maxOutputTokens": self.max_output_tokens
+                if self.max_output_tokens is not None
+                else _DEFAULT_TOOLS_MAX_OUTPUT_TOKENS,
+            },
         }
         if function_declarations:
             payload["tools"] = [{"functionDeclarations": function_declarations}]

--- a/monix/llm/prompts.py
+++ b/monix/llm/prompts.py
@@ -41,4 +41,11 @@ answering, check this timestamp; if the user is asking about the "current"
 or "latest" state and the data is stale (e.g., tens of seconds old or
 older), call the same tool again to refresh. Reuse prior tool results when
 they are still recent enough to avoid redundant calls.
+
+[Output Format]
+Do not use Markdown bold syntax. Never wrap text in double asterisks
+(`**text**`) or double underscores (`__text__`). The rendered output is
+plain terminal text, so emphasis markers appear as literal characters and
+hurt readability. If you need to highlight a key value, quote it with
+backticks or place it on its own line; do not use bold.
 """

--- a/monix/llm/runner.py
+++ b/monix/llm/runner.py
@@ -27,11 +27,16 @@ def run_query(question: str, *, history: Optional[list[dict]] = None) -> Optiona
     max_calls = _resolve_max_calls()
     token_budget = _resolve_token_budget()
     tool_result_max_bytes = _resolve_tool_result_max_bytes()
+    max_output_tokens = _resolve_max_output_tokens()
 
     chat_history: History = history if history is not None else []
     chat_history.append({"role": "user", "parts": [{"text": question}]})
 
-    client = GeminiClient(api_key=api_key, model=model)
+    client = GeminiClient(
+        api_key=api_key,
+        model=model,
+        max_output_tokens=max_output_tokens,
+    )
     tool_schemas = registry.list_tools()
 
     total_tokens = 0
@@ -114,6 +119,24 @@ def _resolve_tool_result_max_bytes() -> int:
         "MONIX_LLM_TOOL_RESULT_MAX_BYTES",
         _DEFAULT_TOOL_RESULT_MAX_BYTES,
     )
+
+
+def _resolve_max_output_tokens() -> Optional[int]:
+    """Read ``MONIX_LLM_MAX_OUTPUT_TOKENS`` and return an int or ``None``.
+
+    Returning ``None`` lets :class:`GeminiClient` keep its per-method
+    built-in defaults (1024 for ``chat``, 2048 for ``chat_with_tools``).
+    """
+    raw = os.environ.get("MONIX_LLM_MAX_OUTPUT_TOKENS")
+    if raw is None:
+        return None
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    return value
 
 
 def _resolve_positive_int(name: str, default: int) -> int:

--- a/monix/llm/tests/test_client.py
+++ b/monix/llm/tests/test_client.py
@@ -187,3 +187,49 @@ def test_legacy_chat_extracts_text():
     with patch("urllib.request.urlopen", side_effect=fake_urlopen):
         out = client.chat([{"role": "user", "parts": [{"text": "hi"}]}])
     assert out == "hi"
+
+
+def test_max_output_tokens_defaults_per_method():
+    """When ``max_output_tokens`` is unset, each method uses its own default."""
+    client = GeminiClient(_API_KEY, MODEL_FLASH)
+    captured = {}
+
+    payload = {
+        "candidates": [{"content": {"role": "model", "parts": [{"text": "ok"}]}}],
+        "usageMetadata": {"totalTokenCount": 1},
+    }
+
+    def fake_urlopen(request, timeout):
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        return _success_response(payload)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        client.chat([{"role": "user", "parts": [{"text": "hi"}]}])
+    assert captured["body"]["generationConfig"]["maxOutputTokens"] == 1024
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        client.chat_with_tools([{"role": "user", "parts": [{"text": "hi"}]}], [])
+    assert captured["body"]["generationConfig"]["maxOutputTokens"] == 2048
+
+
+def test_max_output_tokens_override_applies_to_both_methods():
+    """Explicit ``max_output_tokens`` overrides defaults in both entry points."""
+    client = GeminiClient(_API_KEY, MODEL_FLASH, max_output_tokens=512)
+    captured = {}
+
+    payload = {
+        "candidates": [{"content": {"role": "model", "parts": [{"text": "ok"}]}}],
+        "usageMetadata": {"totalTokenCount": 1},
+    }
+
+    def fake_urlopen(request, timeout):
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        return _success_response(payload)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        client.chat([{"role": "user", "parts": [{"text": "hi"}]}])
+    assert captured["body"]["generationConfig"]["maxOutputTokens"] == 512
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        client.chat_with_tools([{"role": "user", "parts": [{"text": "hi"}]}], [])
+    assert captured["body"]["generationConfig"]["maxOutputTokens"] == 512

--- a/monix/llm/tests/test_prompts.py
+++ b/monix/llm/tests/test_prompts.py
@@ -29,3 +29,10 @@ def test_system_prompt_contains_core_sections():
     assert "tail_log" in SYSTEM_PROMPT
     # Freshness guidance
     assert "measured_at" in SYSTEM_PROMPT
+
+
+def test_system_prompt_forbids_bold_markdown():
+    """The output-format rule must explicitly ban Markdown bold."""
+    assert "Output Format" in SYSTEM_PROMPT
+    assert "Do not use Markdown bold" in SYSTEM_PROMPT
+    assert "**text**" in SYSTEM_PROMPT

--- a/monix/llm/tests/test_runner.py
+++ b/monix/llm/tests/test_runner.py
@@ -99,6 +99,25 @@ def test_resolve_tool_result_max_bytes(monkeypatch, value, expected):
     assert runner._resolve_tool_result_max_bytes() == expected
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        ("", None),
+        ("garbage", None),
+        ("0", None),
+        ("-5", None),
+        ("4096", 4096),
+    ],
+)
+def test_resolve_max_output_tokens(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("MONIX_LLM_MAX_OUTPUT_TOKENS", raising=False)
+    else:
+        monkeypatch.setenv("MONIX_LLM_MAX_OUTPUT_TOKENS", value)
+    assert runner._resolve_max_output_tokens() == expected
+
+
 def test_run_query_returns_none_when_no_api_key(monkeypatch):
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     history: list[dict] = []


### PR DESCRIPTION
- GeminiClient에 max_output_tokens 인자 추가, MONIX_LLM_MAX_OUTPUT_TOKENS 환경변수로 chat/chat_with_tools 양쪽 maxOutputTokens 일괄 제어
- 환경변수 미설정/잘못된 값이면 기존 메서드별 기본값(1024/2048) 유지
- SYSTEM_PROMPT에 [Output Format] 섹션 추가 — **볼드** 마크다운 사용 금지
- 환경변수 해석은 runner._resolve_max_output_tokens()에 단일 출처로 한정